### PR TITLE
fix: Null Pointer Exception on `com.google.protobuf.Timestamp`.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/ValueManager.java
+++ b/src/main/java/org/spin/service/grpc/util/ValueManager.java
@@ -168,7 +168,10 @@ public class ValueManager {
 	
 	public static com.google.protobuf.Timestamp getTimestampFromDate(Timestamp value) {
 		if (value == null) {
-			return null;
+			// return com.google.protobuf.Timestamp.newBuilder().build(); // 1970-01-01T00:00:00Z
+			// return com.google.protobuf.Timestamp.getDefaultInstance(); // 1970-01-01T00:00:00Z
+			// return com.google.protobuf.util.Timestamps.EPOCH; // 1970-01-01T00:00:00Z
+			return com.google.protobuf.util.Timestamps.MIN_VALUE; // 0001-01-01T00:00:00Z
 		}
 		return fromMillis(value.getTime());
 	}


### PR DESCRIPTION

```
===========> PointOfSalesForm.listPointOfSales: null [20]
java.lang.NullPointerException
        at org.spin.backend.grpc.pos.Campaign$Builder.setStartDate(Campaign.java:852)
        at org.spin.pos.util.POSConvertUtil.convertCampaign(POSConvertUtil.java:112)
        at org.spin.pos.util.POSConvertUtil.convertCampaign(POSConvertUtil.java:93)
        at org.spin.grpc.service.PointOfSalesForm.convertPointOfSales(PointOfSalesForm.java:5008)
        at org.spin.grpc.service.PointOfSalesForm.lambda$131(PointOfSalesForm.java:4841)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at org.spin.grpc.service.PointOfSalesForm.listPointOfSales(PointOfSalesForm.java:4840)
        at org.spin.grpc.service.PointOfSalesForm.listPointOfSales(PointOfSalesForm.java:201)
        at org.spin.backend.grpc.pos.StoreGrpc$MethodHandlers.invoke(StoreGrpc.java:6392)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:351)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:860)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```