### PR TITLE
fix: Empty `com.google.protobuf.Timestamp` to `Timestamp`.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/ValueManager.java
+++ b/src/main/java/org/spin/service/grpc/util/ValueManager.java
@@ -234,17 +234,21 @@ public class ValueManager {
 		}
 		return new BigDecimal(validValue);
 	}
-	
+
 	/**
 	 * Get Date from value
 	 * @param dateValue
 	 * @return
 	 */
 	public static Timestamp getDateFromTimestampDate(com.google.protobuf.Timestamp dateValue) {
-		if(dateValue == null) {
+		if(dateValue == null || dateValue.isInitialized() || (dateValue.getSeconds() == 0 && dateValue.getNanos() == 0)) {
 			return null;
 		}
-		LocalDateTime dateTime = LocalDateTime.ofEpochSecond(dateValue.getSeconds(), dateValue.getNanos(), ZoneOffset.UTC);
+		LocalDateTime dateTime = LocalDateTime.ofEpochSecond(
+			dateValue.getSeconds(),
+			dateValue.getNanos(),
+			ZoneOffset.UTC
+		);
 		return Timestamp.valueOf(dateTime);
 	}
 


### PR DESCRIPTION
When a date field is omitted or sent empty from the frontend, it tries to convert to a valid value by taking zero as timestamp (`1970-01-01-01T00:00:00Z`), but this is wrong.