### PR TITLE
fi: `com.google.protobuf.Timestamp` always is initialized.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/ValueManager.java
+++ b/src/main/java/org/spin/service/grpc/util/ValueManager.java
@@ -241,7 +241,7 @@ public class ValueManager {
 	 * @return
 	 */
 	public static Timestamp getDateFromTimestampDate(com.google.protobuf.Timestamp dateValue) {
-		if(dateValue == null || dateValue.isInitialized() || (dateValue.getSeconds() == 0 && dateValue.getNanos() == 0)) {
+		if(dateValue == null || (dateValue.getSeconds() == 0 && dateValue.getNanos() == 0)) {
 			return null;
 		}
 		LocalDateTime dateTime = LocalDateTime.ofEpochSecond(


### PR DESCRIPTION
When you send a date field from the frontend, regardless of whether it has a value or is empty, the `isInitialized` flag is always set to true.