### PR TITLE
fix: Load session with `AD_Token` or login. 

### DIFF
--- a/src/main/java/org/spin/service/grpc/authentication/AuthorizationServerInterceptor.java
+++ b/src/main/java/org/spin/service/grpc/authentication/AuthorizationServerInterceptor.java
@@ -66,10 +66,6 @@ public class AuthorizationServerInterceptor implements ServerInterceptor {
 	}
 
 
-	AuthorizationServerInterceptor(List<String> allowRequestsWithoutToken) {
-		this.ALLOW_REQUESTS_WITHOUT_TOKEN = allowRequestsWithoutToken;
-	}
-
 
 	@Override
     public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> serverCall, Metadata metadata, ServerCallHandler<ReqT, RespT> serverCallHandler) {
@@ -95,6 +91,7 @@ public class AuthorizationServerInterceptor implements ServerInterceptor {
                 return Contexts.interceptCall(context, serverCall, metadata, serverCallHandler);
             } catch (Exception e) {
                 status = Status.UNAUTHENTICATED.withDescription(e.getMessage()).withCause(e);
+				e.printStackTrace();
             }
         }
 

--- a/src/main/java/org/spin/service/grpc/authentication/SessionManager.java
+++ b/src/main/java/org/spin/service/grpc/authentication/SessionManager.java
@@ -749,6 +749,7 @@ public class SessionManager {
 			pstmt = null;
 		} catch (SQLException e) {
 			log.log(Level.SEVERE, tableName + " (" + sql + ")", e);
+			e.printStackTrace();
 			return;
 		} finally {
 			DB.close(rs, pstmt);


### PR DESCRIPTION

When you have a third party token generated from ADempiere, it must always create a new session to return the values, however with a normal login, it should not validate the third party token but get the values of the session from that login.