### PR TITLE
fix: Return null when string is empty value.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/value/NumberManager.java
+++ b/src/main/java/org/spin/service/grpc/util/value/NumberManager.java
@@ -176,13 +176,24 @@ public class NumberManager {
 				(BigDecimal) value
 			);
 		} else if (value instanceof String) {
-			try {
-				integerValue = Integer.valueOf(
-					(String) value
-				);
-			} catch (Exception e) {
-				integerValue = null;
-			}
+			integerValue = getIntegerFromString(
+				(String) value
+			);
+		}
+		return integerValue;
+	}
+
+	public static Integer getIntegerFromString(String stringValue) {
+		Integer integerValue = null;
+		if (Util.isEmpty(stringValue, true)) {
+			return integerValue;
+		}
+		try {
+			integerValue = Integer.valueOf(
+				stringValue
+			);
+		} catch (Exception e) {
+			integerValue = null;
 		}
 		return integerValue;
 	}

--- a/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
+++ b/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
@@ -122,7 +122,7 @@ public class ValueManager {
 		} else if (DisplayType.isDate(referenceId)) {
 			return getValueFromTimestamp(null);
 		} else if (DisplayType.isText(referenceId)) {
-			return getValueFromString(null);
+			;
 		} else if (DisplayType.YesNo == referenceId) {
 			return getValueFromBoolean(false);
 		}

--- a/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
+++ b/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
@@ -20,6 +20,7 @@ import static com.google.protobuf.util.Timestamps.fromMillis;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.DecimalFormat;
@@ -122,6 +123,8 @@ public class ValueManager {
 			return getValueFromTimestamp(null);
 		} else if (DisplayType.isText(referenceId)) {
 			return getValueFromString(null);
+		} else if (DisplayType.YesNo == referenceId) {
+			return getValueFromBoolean(false);
 		}
 		return getValueFromNull();
 	}
@@ -158,6 +161,9 @@ public class ValueManager {
 	 * @return
 	 */
 	public static Value.Builder getValueFromString(String value) {
+		if (value == null) {
+			return getValueFromNull();
+		}
 		return Value.newBuilder().setStringValue(
 			validateNull(value)
 		);
@@ -472,6 +478,7 @@ public class ValueManager {
 		} else if(DisplayType.isText(referenceId)) {
 			return getValueFromString((String) value);
 		} else if (DisplayType.List == referenceId) {
+	 		// TODO: Verify if text and list y same data type
 			return getValueFromObject(value);
 		} else if (DisplayType.Button == referenceId) {
 			if (value instanceof Integer) {
@@ -491,7 +498,7 @@ public class ValueManager {
 					(String) value
 				);
 			}
-			return getValueFromObject(value); 
+			return getValueFromObject(value);
 		}
 		//
 		return builderValue;
@@ -510,22 +517,14 @@ public class ValueManager {
 				value.toString(),
 				true
 			);
-		} else if (displayTypeId == DisplayType.Amount) {
-			DecimalFormat amountFormat = DisplayType.getNumberFormat(
-				DisplayType.Amount,
-				Env.getLanguage(Env.getCtx())
-			);
-			displayedValue = amountFormat.format(
-				NumberManager.getBigDecimalFromString(
-					value.toString()
-				)
-			);
 		} else if (displayTypeId == DisplayType.Integer) {
 			DecimalFormat intFormat = DisplayType.getNumberFormat(
 				DisplayType.Integer,
 				Env.getLanguage(Env.getCtx())
 			);
-			displayedValue = intFormat.format(Integer.valueOf(value.toString()));
+			displayedValue = intFormat.format(
+				Integer.valueOf(value.toString())
+			);
 		} else if (DisplayType.isNumeric(displayTypeId)) {
 			if (I_C_Order.COLUMNNAME_ProcessedOn.equals(columnName)) {
 				if (value.toString().indexOf(".") > 0) {
@@ -625,7 +624,12 @@ public class ValueManager {
 			return convertedValues;
 		}
 		values.keySet().forEach(keyValue -> {
-			convertedValues.put(keyValue, getObjectFromValue(values.get(keyValue)));
+			Value valueBuilder = values.get(keyValue);
+			Object valueItem = getObjectFromValue(valueBuilder);
+			convertedValues.put(
+				keyValue,
+				valueItem
+			);
 		});
 		//	
 		return convertedValues;
@@ -642,11 +646,13 @@ public class ValueManager {
 
 		if (values != null && values.size() > 0) {
 			values.keySet().forEach(keyValue -> {
+				Object valueItem = values.get(keyValue);
+				Value.Builder valueBuilder = getValueFromObject(
+					valueItem
+				);
 				mapValue.putFields(
 					keyValue,
-					getValueFromObject(
-						values.get(keyValue)
-					).build()
+					valueBuilder.build()
 				);
 			});
 		}
@@ -797,13 +803,25 @@ public class ValueManager {
 	 * @return
 	 */
 	public static String getDecodeUrl(String value) {
+		// URL decode to change characteres
+		return getDecodeUrl(
+			value,
+			StandardCharsets.UTF_8
+		);
+	}
+	/**
+	 * Get Decode URL value
+	 * @param value
+	 * @return
+	 */
+	public static String getDecodeUrl(String value, Charset charsetType) {
 		if (Util.isEmpty(value, true)) {
 			return value;
 		}
 		// URL decode to change characteres
 		String parseValue = URLDecoder.decode(
 			value,
-			StandardCharsets.UTF_8
+			charsetType
 		);
 		return parseValue;
 	}


### PR DESCRIPTION
When string is `null` return empty string `""`. this is incorrect since they are different values that can be handled equally in some occasions, and differently in others.

### Request
```bash
curl --location --request GET 'http://192.168.3.53:8080/api/general-ledger/accounts/combinations/234' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIxMDAyMjI5IiwiQURfQ2xpZW50X0lEIjoxMSwiQURfT3JnX0lEIjo1MDAwMSwiQURfUm9sZV9JRCI6MTAyLCJBRF9Vc2VyX0lEIjoxMDEsIk1fV2FyZWhvdXNlX0lEIjo1MDAwMiwiQURfTGFuZ3VhZ2UiOiJlc19NWCIsImlhdCI6MTcwMTI3NTMwNCwiZXhwIjoxNzAxMzYxNzA0fQ.gSqArq6mjQBL_2rcwLboLAQhOFi9STXrpYorQQC9zxU'
```

### Response

See `Alias` column.

Before changes
```json
{
    "id": 234,
    "table_name": "C_ValidCombination",
    "values": {
        "C_ValidCombination_ID": 234,
        "Alias": "",
        "Combination": "HQ-12110-_-_-_-_-_"
    }
}
```

After changes
```json
{
    "id": 234,
    "table_name": "C_ValidCombination",
    "values": {
        "C_ValidCombination_ID": 234,
        "Alias": null,
        "Combination": "HQ-12110-_-_-_-_-_"
    }
}
```
