### PR TITLE
fix: Count `JOIN` clause.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/db/CountUtil.java
+++ b/src/main/java/org/spin/service/grpc/util/db/CountUtil.java
@@ -52,11 +52,15 @@ public class CountUtil {
 		// tableName tableName, tableName AS tableName
 		String tableWithAliases = FromUtil.getPatternTableName(tableName, tableNameAlias);
 
-		Matcher matcherFrom = Pattern.compile(
-			"\\s+(FROM)\\s+(" + tableWithAliases + ")\\s+(WHERE|(LEFT|INNER|RIGHT)\\s+JOIN)",
+		String regex = "\\s+(FROM)\\s+(" + tableWithAliases + ")\\s+(WHERE|((LEFT|INNER|RIGHT|FULL|OUTER|SELF|CROSS)\\s+){0,1}JOIN)";
+
+		Pattern pattern = Pattern.compile(
+			regex,
 			Pattern.CASE_INSENSITIVE | Pattern.DOTALL
-		)
-		.matcher(sql);
+		);
+
+		Matcher matcherFrom = pattern
+			.matcher(sql);
 
 		List<MatchResult> fromWhereParts = matcherFrom.results()
 			.collect(Collectors.toList());


### PR DESCRIPTION
When the query has a simple `JOIN` without preceding `RIGTH`, `INNER`, or `LEFT` does not match the text.


![imagen](https://github.com/adempiere/adempiere-grpc-utils/assets/20288327/c18bee8b-1ff1-492b-aa9e-82ea16dff008)


In addition, support for `JOIN`: `SELFT`, `CROSS`, `FULL`, and `OUTER` variants has been added.
