### PR TITLE
fix: Count records with `LEFT OUTER JOIN`.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/db/CountUtil.java
+++ b/src/main/java/org/spin/service/grpc/util/db/CountUtil.java
@@ -52,7 +52,7 @@ public class CountUtil {
 		// tableName tableName, tableName AS tableName
 		String tableWithAliases = FromUtil.getPatternTableName(tableName, tableNameAlias);
 
-		String regex = "\\s+(FROM)\\s+(" + tableWithAliases + ")\\s+(WHERE|((LEFT|INNER|RIGHT|FULL|OUTER|SELF|CROSS)\\s+){0,1}JOIN)";
+		String regex = "\\s+(FROM)\\s+(" + tableWithAliases + ")\\s+(WHERE|((LEFT|INNER|RIGHT|FULL|SELF|CROSS)\\s+(OUTER\\s+){0,1}){0,1}JOIN)";
 
 		Pattern pattern = Pattern.compile(
 			regex,
@@ -63,7 +63,10 @@ public class CountUtil {
 			.matcher(sql);
 
 		List<MatchResult> fromWhereParts = matcherFrom.results()
-			.collect(Collectors.toList());
+			.collect(
+				Collectors.toList()
+			)
+		;
 		int positionFrom = -1;
 		if (fromWhereParts != null && fromWhereParts.size() > 0) {
 			// MatchResult lastFrom = fromWhereParts.get(fromWhereParts.size() - 1);

--- a/src/main/java/org/spin/service/grpc/util/db/LimitUtil.java
+++ b/src/main/java/org/spin/service/grpc/util/db/LimitUtil.java
@@ -15,7 +15,6 @@
 package org.spin.service.grpc.util.db;
 
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.compiere.util.Util;
 
@@ -102,18 +101,25 @@ public class LimitUtil {
 	 * @return
 	 */
 	public static String getQueryWithLimit(String query, int limit, int offset) {
-		Matcher matcher = Pattern.compile(
-			OrderByUtil.SQL_ORDER_BY_REGEX,
-			Pattern.CASE_INSENSITIVE | Pattern.DOTALL
-		).matcher(query);
-		int positionFrom = -1;
+		Matcher matcher = OrderByUtil.SQL_ORDER_BY_PATTERN
+			.matcher(query)
+		;
+
+		String sql = query;
 		if(matcher.find()) {
-			positionFrom = matcher.start();
-			query = query.substring(0, positionFrom) + " AND ROWNUM >= " + offset + " AND ROWNUM <= " + limit + " " + query.substring(positionFrom);
+			int positionFrom = matcher.start();
+			sql = query.substring(0, positionFrom)
+				+ " AND ROWNUM >= " + offset
+				+ " AND ROWNUM <= " + limit
+				+ " " + query.substring(positionFrom)
+			;
 		} else {
-			query = query + " AND ROWNUM >= " + offset + " AND ROWNUM <= " + limit;
+			sql = query
+				+ " AND ROWNUM >= " + offset
+				+ " AND ROWNUM <= " + limit
+			;
 		}
-		return query;
+		return sql;
 	}
 
 }


### PR DESCRIPTION
Match with ` FROM M_Product p LEFT JOIN` and not match with ` FROM M_Product p LEFT OUTER JOIN` (with `OUTER` clause).

![imagen](https://github.com/adempiere/adempiere-grpc-utils/assets/20288327/8bdf2c54-aded-41f1-ae4a-c117624b1825)
