### PR TITLE
fix: When sql contains no where clause restrictions `CountUtil.countRecords` returns zero.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/db/FromUtil.java
+++ b/src/main/java/org/spin/service/grpc/util/db/FromUtil.java
@@ -54,7 +54,7 @@ public class FromUtil {
 
 		// tableName tableAlias, tableName AS tableAlias
 		String patternOnlyTableAlias = "";
-		if (!Util.isEmpty(tableNameAlias, true) && !tableName.equals(tableNameAlias)) {
+		if (!Util.isEmpty(tableNameAlias, true) && !tableName.trim().equals(tableNameAlias.trim())) {
 			patternOnlyTableAlias = tableName + "\\s+" + tableNameAlias + "|" + tableName + "\\s+AS\\s+" + tableNameAlias;
 			patternTableWithAliases = patternOnlyTableAlias;
 		}


### PR DESCRIPTION
Original SQL:
```sql
SELECT C_BankAccount.C_BankAccount_ID,NULL,
	COALESCE((SELECT COALESCE(C_Bank.Name,'')||' - '||COALESCE(C_Bank.RoutingNo,'') FROM C_Bank WHERE C_BankAccount.C_Bank_ID=C_Bank.C_Bank_ID),'-1') ||'_'|| COALESCE(C_BankAccount.AccountNo,'-1') ||'_'|| COALESCE((SELECT COALESCE(C_Currency.ISO_Code,'') FROM C_Currency WHERE C_BankAccount.C_Currency_ID=C_Currency.C_Currency_ID),'-1'),
	C_BankAccount.IsActive,
	C_BankAccount.UUID 
FROM C_BankAccount 
ORDER BY 3
```

Generate SQL
```sql
SELECT COUNT(*)
FROM C_BankAccount 
ORDER BY 3
```



https://github.com/adempiere/adempiere-grpc-utils/assets/20288327/375ef408-f9f4-4443-83b2-5d33335627bc



fixes https://github.com/solop-develop/frontend-core/issues/2012
