### PR TITLE
fix: Smart Browse process selection with decimal values.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
+++ b/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
@@ -645,7 +645,7 @@ public class ValueManager {
 		}
 		values.keySet().forEach(keyValue -> {
 			Value valueBuilder = values.get(keyValue);
-			Object valueItem = getObjectFromValue(valueBuilder);
+			Object valueItem = ValueManager.getObjectFromValue(valueBuilder);
 			convertedValues.put(
 				keyValue,
 				valueItem
@@ -654,7 +654,44 @@ public class ValueManager {
 		//	
 		return convertedValues;
 	}
-	
+
+	/**
+	 * Convert Selection values from gRPC to ADempiere values
+	 * @param values
+	 * @param displayTypeColumns <ColumnName, DisplayType>
+	 * @return
+	 */
+	public static Map<String, Object> convertValuesMapToObjects(Map<String, Value> values, Map<String, Integer> displayTypeColumns) {
+		Map<String, Object> convertedValues = new HashMap<>();
+		if (values == null || values.size() <= 0) {
+			return convertedValues;
+		}
+		if (displayTypeColumns == null || values.size() <= 0) {
+			return ValueManager.convertValuesMapToObjects(
+				values
+			);
+		}
+		values.keySet().forEach(keyValue -> {
+			Value valueBuilder = values.get(keyValue);
+			Object valueItem = getObjectFromValue(valueBuilder);
+
+			Integer displayType = displayTypeColumns.get(keyValue);
+			if (displayType != null && displayType.intValue() > 0) {
+				valueItem = ValueManager.getObjectFromReference(
+					valueBuilder,
+					displayType.intValue()
+				);
+			}
+
+			convertedValues.put(
+				keyValue,
+				valueItem
+			);
+		});
+		//	
+		return convertedValues;
+	}
+
 	/**
 	 * Convert Selection values from gRPC to ADempiere values
 	 * @param values


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


#### Screenshot or Gif


https://github.com/solop-develop/frontend-core/assets/20288327/69a33dbb-db22-4144-80d3-14ca05f34571



#### Expected behavior
```bash
curl 'http://spdev01.solopapp.com:24610/api/business-data/process/2000189/smart-browse/2000038' \
  -X POST \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDIwNzI1IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDIsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDA0LCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzE5NTE4ODE5LCJleHAiOjE3MTk2MDUyMTl9.qRF54QqKTARdpWiMeHOCtJpQrEADBFkWX6XX480roVY' \
  --data-raw '{"record_id":1007787,"parameters":{"C_ProjectPhase_ID":1014318},"selections":[{"selectionId":1004825,"values":{"P_M_Product_ID":1004825,"P_QtyEntered":{"type":"decimal","value":20}}}]}'
```

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- Yarn version:
- adempiere-vue version: <!-- 4.4.0. -->

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2374
