### PR TITLE
feat: Add `ECA56_DictionaryCode` on session context.

### DIFF
--- a/src/main/java/org/spin/service/grpc/authentication/SessionManager.java
+++ b/src/main/java/org/spin/service/grpc/authentication/SessionManager.java
@@ -390,6 +390,7 @@ public class SessionManager {
 	 * @return
 	 */
 	private static String getJWT_SecretKey() {
+		// TODO: Verify cache
 		// get by SysConfig client
 		String secretKey = MSysConfig.getValue(
 			JWTUtil.ECA52_JWT_SECRET_KEY,
@@ -577,6 +578,14 @@ public class SessionManager {
 		Env.setContext(context, "#AD_Client_Name", client.getName());
 		Env.setContext(context, "#Date", new Timestamp(System.currentTimeMillis()));
 		Env.setContext(context, Env.LANGUAGE, getDefaultLanguage(language));
+
+		MClientInfo clientInfoSystem = MClientInfo.get(context, 0);
+		String dictionaryCode = "";
+		if (clientInfoSystem.get_ColumnIndex("ECA56_DictionaryCode") >= 0) {
+			dictionaryCode = clientInfoSystem.get_ValueAsString(dictionaryCode);
+		}
+		Env.setContext(context, "#ECA56_DictionaryCode", dictionaryCode);
+
 		//	Role Info
 		MRole role = MRole.get(context, Env.getContextAsInt(context, "#AD_Role_ID"));
 		Env.setContext(context, "#AD_Role_Name", role.getName());


### PR DESCRIPTION


```json
{
	"default_context": {
		"#AD_Client_Name": "System",
		"ECA56_DictionaryCode": "rs1_custom",
		"#M_Warehouse_ID": 0,
		"#C_UOM_ID": 100,
		"#AD_PrintColor_ID": 100,
		"#ShowAcct": false,
		"#AD_Client_ID": 0,
		"#SalesRep_ID": 1001212,
		"#C_Country_ID": 100,
		"#AD_SearchDefinition_ID": 50000,
		"#AD_Role_Name": "System Administrator",
		"#AD_Session_ID": 2021222,
		"#AD_Role_ID": 0,
		"#AD_PrintTableFormat_ID": 100,
		"#AD_PrintPaper_ID": 100,
		"#StdPrecision": 2,
		"#C_Region_ID": 142,
		"#AD_User_Name": "Edwin Betancourt",
		"#SysAdmin": true,
		"#AD_PrintFont_ID": 163,
		"#C_DocBaseType_ID": 50000,
		"#AD_User_ID": 1001212,
		"#C_ConversionType_ID": 114,
		"#YYYY": true,
		"#Session_UUID": "b776d112-e2c5-413f-b7fa-688a92707d3f",
		"#Date": {
			"type": "date",
			"value": "2024-07-15 03:06:32"
		},
		"#AD_Language": "es_MX",
		"#AD_Org_ID": 0
	}
}
```