### PR TITLE
feat: Add support to `ORDER BY` with string.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/query/Order.java
+++ b/src/main/java/org/spin/service/grpc/util/query/Order.java
@@ -24,7 +24,7 @@ import java.util.Map;
 public class Order {
 
 	public static final String ASCENDING = "asc";
-	public static final String DESCENDING = "des";
+	public static final String DESCENDING = "desc";
 	//	
 	public static final String NAME = "name";
 	public static final String TYPE = "type";
@@ -47,4 +47,5 @@ public class Order {
 	public String toString() {
 		return "Order [getColumnName()=" + getColumnName() + ", getSortType()=" + getSortType() + "]";
 	}
+
 }


### PR DESCRIPTION
#### Request
```bash
curl --location --request GET 'http://192.168.3.53/api/user-interface/entities/186?record_reference_uuid=&search_value=&context_attributes=%7B%7D&page_token=1&page_size=15&sort_by=DocumentNo%20ASC' \
--header 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0' \
--header 'Accept: application/json, text/plain, */*' \
--header 'Accept-Language: es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDIyNTEzIiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDMsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDEyMTIsIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDQ1LCJBRF9MYW5ndWFnZSI6ImVuX1VTIiwiaWF0IjoxNzI2MjM2MjU5LCJleHAiOjE3MjYzMjI2NTl9.-Ed81ejkt6bxZPA-cQhJ081ovsUyiUgbzyi2ebhqPUU' \
--header 'Connection: keep-alive' \
--header 'Priority: u=0'
```


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/2630