### PR TITLE
fix: `Integer` object cast to String.

### DIFF
--- a/src/main/java/org/spin/service/grpc/util/value/StringManager.java
+++ b/src/main/java/org/spin/service/grpc/util/value/StringManager.java
@@ -42,8 +42,8 @@ public class StringManager {
 		if (value == null) {
 			return null;
 		}
-		// return value.toString();
-		return (String) value;
+		// return (String) value;
+		return value.toString();
 	}
 
 }


### PR DESCRIPTION
When set `Integer` as parameter, generates error:
```log
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String 
(java.lang.Integer and java.lang.String are in module java.base of loader 'bootstrap')
```
