### PR TITLE
fix: User login load preferences on first time.

### DIFF
--- a/src/main/java/org/spin/service/grpc/authentication/SessionManager.java
+++ b/src/main/java/org/spin/service/grpc/authentication/SessionManager.java
@@ -59,6 +59,7 @@ import org.compiere.util.Util;
 import org.spin.eca52.util.JWTUtil;
 import org.spin.model.MADToken;
 import org.spin.model.MADTokenDefinition;
+import org.spin.service.grpc.util.base.PreferenceUtil;
 import org.spin.service.grpc.util.value.NumberManager;
 import org.spin.util.IThirdPartyAccessGenerator;
 import org.spin.util.ITokenGenerator;
@@ -337,6 +338,12 @@ public class SessionManager {
 		} else {
 			bearerToken = createAndGetBearerToken(session, warehouseId, Env.getAD_Language(session.getCtx()));
 		}
+
+		// Update session preferences
+		PreferenceUtil.saveSessionPreferences(
+			userId, language, session.getAD_Role_ID(), session.getAD_Client_ID(), session.getAD_Org_ID(), warehouseId
+		);
+
 		return bearerToken;
 	}
 
@@ -605,19 +612,6 @@ public class SessionManager {
 		//	Load preferences
 		loadPreferences(context);
 	}
-	
-	/**
-	 * Get Default Warehouse after login
-	 * @param organizationId
-	 * @return
-	 */
-	public static int getDefaultWarehouseId(int organizationId) {
-		if (organizationId < 0) {
-			return -1;
-		}
-		String sql = "SELECT M_Warehouse_ID FROM M_Warehouse WHERE IsActive = 'Y' AND AD_Org_ID = ? AND IsInTransit='N'";
-		return DB.getSQLValue(null, sql, organizationId);
-	}
 
 	/**
 	 * Get Default role after login
@@ -662,6 +656,19 @@ public class SessionManager {
 				+ ") "
 			+ "ORDER BY o.AD_Org_ID DESC, o.Name";
 		return DB.getSQLValue(null, organizationSQL, roleId, userId);
+	}
+	
+	/**
+	 * Get Default Warehouse after login
+	 * @param organizationId
+	 * @return
+	 */
+	public static int getDefaultWarehouseId(int organizationId) {
+		if (organizationId < 0) {
+			return -1;
+		}
+		String sql = "SELECT M_Warehouse_ID FROM M_Warehouse WHERE IsActive = 'Y' AND AD_Org_ID = ? AND IsInTransit='N' ORDER BY Name";
+		return DB.getSQLValue(null, sql, organizationId);
 	}
 
 	/**

--- a/src/main/java/org/spin/service/grpc/util/base/PreferenceUtil.java
+++ b/src/main/java/org/spin/service/grpc/util/base/PreferenceUtil.java
@@ -1,0 +1,150 @@
+/************************************************************************************
+ * Copyright (C) 2018-present E.R.P. Consultores y Asociados, C.A.                  *
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com                     *
+ * This program is free software: you can redistribute it and/or modify             *
+ * it under the terms of the GNU General Public License as published by             *
+ * the Free Software Foundation, either version 2 of the License, or                *
+ * (at your option) any later version.                                              *
+ * This program is distributed in the hope that it will be useful,                  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of                   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                     *
+ * GNU General Public License for more details.                                     *
+ * You should have received a copy of the GNU General Public License                *
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.            *
+ ************************************************************************************/
+package org.spin.service.grpc.util.base;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.adempiere.core.domains.models.I_AD_Preference;
+import org.compiere.model.MPreference;
+import org.compiere.model.Query;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+public class PreferenceUtil {
+	/** Language			*/
+	public static final String P_LANGUAGE = "Language";
+
+	/** Role */
+	public static final String P_ROLE = "Role";
+
+	/** Client Name */
+	public static final String P_CLIENT = "Client";
+
+	/** Org Name */
+	public static final String P_ORG = "Organization";
+
+	/** Warehouse Name */
+	public static final String P_WAREHOUSE = "Warehouse";
+
+
+	public static List<String> PROPERTIES_LIST = Arrays.asList(
+		P_LANGUAGE, P_ROLE, P_CLIENT, P_ORG, P_WAREHOUSE
+	);
+
+
+	/**
+	 * Get Session Preferences
+	 * @param userId
+	 * @return
+	 */
+	public static List<MPreference> getSessionPreferences(int userId) {
+		List<MPreference> preferencesList = new ArrayList<MPreference>();
+		if (userId <= 0) {
+			return preferencesList;
+		}
+
+		ArrayList<Object> queryParameters = new ArrayList<>();
+		queryParameters.add(userId);
+		queryParameters.addAll(PreferenceUtil.PROPERTIES_LIST);
+
+		preferencesList = new Query(
+			Env.getCtx(),
+			I_AD_Preference.Table_Name,
+			"AD_User_ID = ? AND Attribute IN(?, ?, ?, ?, ?) AND AD_Window_ID Is NULL",
+			null
+		)
+			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
+			.setParameters(queryParameters)
+			.<MPreference>list()
+		;
+		return preferencesList;
+	}
+
+
+	/**
+	 * Save Session Preferences
+	 * @param userId
+	 * @param language
+	 * @param roleId
+	 * @param clientId
+	 * @param organizationId
+	 * @param warehouseId
+	 */
+	public static void saveSessionPreferences(
+		// query
+		int userId,
+		// values
+		String language, int roleId, int clientId, int organizationId, int warehouseId
+	) {
+		if (userId <= 0) {
+			return;
+		}
+
+		Query query = new Query(
+			Env.getCtx(),
+			I_AD_Preference.Table_Name,
+			"AD_User_ID = ? AND Attribute = ? AND AD_Window_ID Is NULL",
+			null
+		)
+			.setOrderBy(I_AD_Preference.COLUMNNAME_Created + " DESC")
+		;
+
+		for (String attributeName : PROPERTIES_LIST) {
+			if (Util.isEmpty(attributeName, true)) {
+				// next iteration
+				continue;
+			}
+			MPreference preference = query
+				.setParameters(userId, attributeName)
+				.first()
+			;
+			if (preference == null) {
+				preference = new MPreference(Env.getCtx(), 0, null);
+				preference.setAD_User_ID(userId);
+				preference.setAttribute(attributeName);
+			} 
+			if (preference.getAD_Client_ID() > 0 || preference.getAD_Org_ID() > 0) {
+				preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Client_ID, 0);
+				preference.set_ValueOfColumn(I_AD_Preference.COLUMNNAME_AD_Org_ID, 0);
+			}
+			// set values
+			if (attributeName.equals(PreferenceUtil.P_ROLE)) {
+				preference.setValue(
+					String.valueOf(roleId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_CLIENT)) {
+				preference.setValue(
+					String.valueOf(clientId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_ORG)) {
+				preference.setValue(
+					String.valueOf(organizationId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_WAREHOUSE)) {
+				preference.setValue(
+					String.valueOf(warehouseId)
+				);
+			} else if (attributeName.equals(PreferenceUtil.P_LANGUAGE)) {
+				preference.setValue(
+					language
+				);
+			}
+			preference.save();
+		}
+	}
+
+}


### PR DESCRIPTION
## Bug report

If a user logs in for the first time or does not have saved session preferences, when logging in, the system preferences are never saved, so that when logging back in the system does not have the data of the last session by default.

#### Steps to reproduce

1. Delete user preferences.
2. Log in with that user.
3. Go to the preferences and look for the ones related to that user.



#### Additional context
This only affects logins using grpc utils or based on grpc utils.