### PR TITLE
fix: Remove build warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 java {
 	sourceCompatibility = JavaVersion.VERSION_11
-	// targetCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 	withJavadocJar()
 	withSourcesJar()
 }

--- a/src/main/java/org/spin/service/grpc/util/db/CountUtil.java
+++ b/src/main/java/org/spin/service/grpc/util/db/CountUtil.java
@@ -66,7 +66,7 @@ public class CountUtil {
 
 	/**
 	 * Count records using transaction name
-	 * @param sql
+	 * @param originalSql
 	 * @param tableName
 	 * @param tableNameAlias
 	 * @param parameters

--- a/src/main/java/org/spin/service/grpc/util/value/TimeManager.java
+++ b/src/main/java/org/spin/service/grpc/util/value/TimeManager.java
@@ -192,7 +192,7 @@ public class TimeManager {
 	 * @link ValueManager.getDateFromTimestampDate
 	 * @param value
 	 * @return
-	 * @see {@link ValueManager.getDateFromTimestampDate(com.google.protobuf.Timestamp)}
+	 * @deprecated {@link ValueManager.getDateFromTimestampDate(com.google.protobuf.Timestamp)}
 	 */
 	@Deprecated
 	public static Timestamp convertValueToDate(com.google.protobuf.Timestamp value) {

--- a/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
+++ b/src/main/java/org/spin/service/grpc/util/value/ValueManager.java
@@ -66,10 +66,11 @@ public class ValueManager {
 
 	/**
 	 * Get Value
-	 * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead.
+	 * @deprecated Use {@link ValueManager#getProtoValueFromObject(Object)} instead.
 	 * @param value
 	 * @return
 	 */
+	@Deprecated
 	public static Value.Builder getValueFromObject(Object value) {
 		return getProtoValueFromObject(value);
 	}
@@ -871,14 +872,15 @@ public class ValueManager {
 
 	/**
 	 * Convert Selection values from gRPC to ADempiere values
-	 * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead. With recursive support
+	 * @deprecated Use {@link ValueManager#getProtoValueFromObject(Object)} instead. With recursive support
 	 * @param values
 	 * @return
 	 */
+	@Deprecated
 	public static Value.Builder convertObjectMapToStruct(Map<String, Object> values) {
 		return getProtoValueFromMap(values);
 	}
-	
+
 	/**
 	 * Default get value from type
 	 * @param valueToConvert
@@ -1073,13 +1075,14 @@ public class ValueManager {
 				|| DisplayType.Locator == displayType
 				|| DisplayType.PAttribute == displayType;
 	}
-	
+
 	/**
 	 * Convert null on ""
 	 * @param value
-	 * @deprecated Use {@link StringManager#getValidString()} instead.
+	 * @deprecated Use {@link StringManager#getValidString(String)} instead.
 	 * @return
 	 */
+	@Deprecated
 	public static String validateNull(String value) {
 		return StringManager.getValidString(
 			value


### PR DESCRIPTION

### Before this changes
```bash
gradle build
```

```
gradle build

> Task :compileJava
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:73: warning: [dep-ann] deprecated item is not annotated with @Deprecated
        public static Value.Builder getValueFromObject(Object value) {
                                    ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:878: warning: [dep-ann] deprecated item is not annotated with @Deprecated
        public static Value.Builder convertObjectMapToStruct(Map<String, Object> values) {
                                    ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:1083: warning: [dep-ann] deprecated item is not annotated with @Deprecated
        public static String validateNull(String value) {
                             ^
Note: src/main/java/org/spin/service/grpc/authentication/TokenManager.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
3 warnings

> Task :javadoc
src/main/java/org/spin/service/grpc/util/db/CountUtil.java:69: warning: @param argument "sql" is not a parameter name.
         * @param sql
           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:874: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead. With recursive support
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:69: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead.
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:1080: warning: Tag @link: reference not found: StringManager#getValidString()
         * @deprecated Use {@link StringManager#getValidString()} instead.
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:69: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead.
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:874: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead. With recursive support
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:1080: warning: Tag @link: reference not found: StringManager#getValidString()
         * @deprecated Use {@link StringManager#getValidString()} instead.
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:874: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead. With recursive support
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:69: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead.
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:1080: warning: Tag @link: reference not found: StringManager#getValidString()
         * @deprecated Use {@link StringManager#getValidString()} instead.
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:874: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead. With recursive support
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:69: warning: Tag @link: reference not found: ValueManager#getProtoValueFromObject()
         * @deprecated Use {@link ValueManager#getProtoValueFromObject()} instead.
                           ^
src/main/java/org/spin/service/grpc/util/value/ValueManager.java:1080: warning: Tag @link: reference not found: StringManager#getValidString()
         * @deprecated Use {@link StringManager#getValidString()} instead.
                           ^
13 warnings

BUILD SUCCESSFUL in 4s
5 actionable tasks: 5 executed
```



### After this changes

```bash
gradle build
```

```bash
BUILD SUCCESSFUL in 2s
5 actionable tasks: 5 executed
```


